### PR TITLE
feat: 세 웹뷰가 토큰을 공유하는 Hook 제작

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
-  "name": "first-test",
+  "name": "react-native-host",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "first-test",
+      "name": "react-native-host",
       "version": "1.0.0",
       "dependencies": {
         "@expo/webpack-config": "~0.16.2",
+        "@react-native-async-storage/async-storage": "~1.17.3",
         "@react-navigation/bottom-tabs": "^6.3.1",
         "@react-navigation/native": "^6.0.10",
         "expo": "~45.0.0",
@@ -4201,6 +4202,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "1.17.6",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.17.6.tgz",
+      "integrity": "sha512-XXnoheQI3vQTQmjphdXNLTmtiKZeRqvI8kPQ25X5Eae7nZjdYEEGN+0z8N2qyelbUIQwKgmW0aagJk56q7DyNg==",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || 0.60 - 0.68 || 1000.0.0"
       }
     },
     "node_modules/@react-native-community/cli": {
@@ -12313,6 +12325,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -14078,6 +14098,17 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -25087,6 +25118,14 @@
         }
       }
     },
+    "@react-native-async-storage/async-storage": {
+      "version": "1.17.6",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.17.6.tgz",
+      "integrity": "sha512-XXnoheQI3vQTQmjphdXNLTmtiKZeRqvI8kPQ25X5Eae7nZjdYEEGN+0z8N2qyelbUIQwKgmW0aagJk56q7DyNg==",
+      "requires": {
+        "merge-options": "^3.0.4"
+      }
+    },
     "@react-native-community/cli": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-7.0.3.tgz",
@@ -31347,6 +31386,11 @@
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ=="
     },
+    "is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
+    },
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -32663,6 +32707,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
+    },
+    "merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "requires": {
+        "is-plain-obj": "^2.1.0"
+      }
     },
     "merge-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "react-native-web": "0.17.7",
     "react-native-webview": "11.18.1",
     "webpack-dev-server": "~3.11.0",
-    "expo-constants": "~13.1.1"
+    "expo-constants": "~13.1.1",
+    "@react-native-async-storage/async-storage": "~1.17.3"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/src/hooks/useToken.js
+++ b/src/hooks/useToken.js
@@ -1,0 +1,34 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { useEffect, useState } from "react";
+import IntegrationService from "../services/integration";
+
+const Storage = new IntegrationService(AsyncStorage);
+
+function useToken() {
+  const [token, setToken] = useState("");
+  const [script, setScript] = useState("");
+
+  useEffect(() => {
+    const updateScript = async () => {
+      const token = await Storage.getTokenFromStorage();
+      const script = `
+        window.isNativeApp = true;
+        window.token = "${token}";
+        true;
+      `;
+
+      setScript(script);
+    };
+    updateScript();
+  }, []);
+
+  useEffect(() => {
+    if (token) {
+      Storage.setTokenToStorage(token);
+    }
+  }, [token]);
+
+  return { script, setToken };
+}
+
+export default useToken;

--- a/src/hooks/useToken.js
+++ b/src/hooks/useToken.js
@@ -1,5 +1,6 @@
-import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useEffect, useState } from "react";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
 import IntegrationService from "../services/integration";
 
 const Storage = new IntegrationService(AsyncStorage);

--- a/src/screens/ChatListScreen.js
+++ b/src/screens/ChatListScreen.js
@@ -1,16 +1,30 @@
-import { View } from "react-native";
+import { useRef } from "react";
 import { WebView } from "react-native-webview";
 
 import Screen from "../components/Screen";
+import useToken from "../hooks/useToken";
 
 function ChatListScreen() {
+  const webviewRef = useRef();
+
+  const { script, setToken } = useToken();
+
+  const handleMessage = ({ nativeEvent }) => {
+    const messageFromWebView = nativeEvent.data;
+
+    if (messageFromWebView.includes("token")) {
+      setToken(messageFromWebView);
+    }
+  };
+
   return (
     <Screen>
-      <View style={{ width: "100%", height: "100%" }}>
-        <WebView
-          source={{ uri: "https://cosmic-semolina-b6e8c3.netlify.app" }}
-        />
-      </View>
+      <WebView
+        source={{ uri: "https://cosmic-semolina-b6e8c3.netlify.app" }}
+        ref={webviewRef}
+        onMessage={handleMessage}
+        injectedJavaScript={script}
+      />
     </Screen>
   );
 }

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -1,21 +1,32 @@
 import { useRef } from "react";
-import { View } from "react-native";
 import { WebView } from "react-native-webview";
+
 import Screen from "../components/Screen";
+import useToken from "../hooks/useToken";
 
 function HomeScreen() {
   const webviewRef = useRef();
 
+  const { script, setToken } = useToken();
+
+  const handleMessage = ({ nativeEvent }) => {
+    const messageFromWebView = nativeEvent.data;
+
+    if (messageFromWebView.includes("token")) {
+      setToken(messageFromWebView);
+    }
+  };
+
   return (
     <Screen>
-      <View style={{ width: "100%", height: "100%" }}>
-        <WebView
-          source={{
-            uri: "https://629b04d5ac0b813c98a5a8a4--preeminent-licorice-96005b.netlify.app/",
-          }}
-          ref={webviewRef}
-        />
-      </View>
+      <WebView
+        source={{
+          uri: "http://192.168.0.29:3000/",
+        }}
+        ref={webviewRef}
+        onMessage={handleMessage}
+        injectedJavaScript={script}
+      />
     </Screen>
   );
 }

--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -1,14 +1,30 @@
-import { View } from "react-native";
+import { useRef } from "react";
 import { WebView } from "react-native-webview";
 
 import Screen from "../components/Screen";
+import useToken from "../hooks/useToken";
 
 function ProfileScreen() {
+  const webviewRef = useRef();
+
+  const { script, setToken } = useToken();
+
+  const handleMessage = ({ nativeEvent }) => {
+    const messageFromWebView = nativeEvent.data;
+
+    if (messageFromWebView.includes("token")) {
+      setToken(messageFromWebView);
+    }
+  };
+
   return (
     <Screen>
-      <View style={{ width: "100%", height: "100%" }}>
-        <WebView source={{ uri: "https://shiny-druid-4172be.netlify.app" }} />
-      </View>
+      <WebView
+        source={{ uri: "https://shiny-druid-4172be.netlify.app" }}
+        ref={webviewRef}
+        onMessage={handleMessage}
+        injectedJavaScript={script}
+      />
     </Screen>
   );
 }

--- a/src/services/integration.js
+++ b/src/services/integration.js
@@ -1,0 +1,15 @@
+class IntegrationService {
+  constructor(storage) {
+    this.storage = storage;
+  }
+
+  getTokenFromStorage = async () => {
+    return await this.storage.getItem("token");
+  };
+
+  setTokenToStorage = async (token) => {
+    await this.storage.setItem("token", token);
+  };
+}
+
+export default IntegrationService;


### PR DESCRIPTION
## 설명

세 개의 웹뷰가 각각 다른 주소를 바라보고 있기 때문에 로그인 상태를 공유하는 로직이 필요합니다.

모든 웹뷰를 감싸고 있는 React Native 에 JWT 를 저장하면 어느 웹뷰로 이동하더라도 같은 토큰을 꺼내올 수 있습니다.

앱을 켜면 자동으로 웹뷰에 AsyncStore 에 들어있는 토큰을 주입(inject) 시켜주는 `useToken` 훅을 만들었습니다.

## 변경 또는 추가한 로직

**설치한 라이브러리:**
1. expo-constants: 안드로이드와 IOS 모두에서 상태 바를 침범하지 않는 커스텀 SafeAreaView 를 만들기 위해.
2. @react-native-async-storage/async-storage: React Native 의 AsyncStorage 를 사용하기 위해.

Service 레이어를 추가했습니다.
- IntegrationService: Integration(통합)의 뜻 처럼 세 개의 웹뷰를 합치는데 필수적인 AsyncStorage 에 접근하는 함수를 export 하는 클래스입니다. useToken 훅에서 사용합니다.