### PR TITLE
feat: 토큰 저장 형식 확정

### DIFF
--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -13,7 +13,9 @@ function HomeScreen() {
     const messageFromWebView = nativeEvent.data;
 
     if (messageFromWebView.includes("token")) {
-      setToken(messageFromWebView);
+      const token = messageFromWebView.split(" ")[1];
+
+      setToken(token);
     }
   };
 


### PR DESCRIPTION
## 설명

웹뷰에서 보내주는 JWT 를 저장하는 방식을 확립했습니다.
웹뷰에서 쏴주는 토큰의 형식은 다음과 같습니다. `token ${token}` (Bearer 형식과 유사)
네이티브에서 `split(' ')[1]` 으로 JWT 만 추출해서 Async Storage 에 저장합니다.

## 변경 또는 추가한 로직
