### PR TITLE
feat: 위치 권한을 요청하고 웹뷰에 삽입하는 Hook 제작

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@react-navigation/native": "^6.0.10",
         "expo": "~45.0.0",
         "expo-constants": "~13.1.1",
+        "expo-location": "~14.2.2",
         "expo-status-bar": "~1.3.0",
         "react": "17.0.2",
         "react-dom": "17.0.2",
@@ -9833,6 +9834,17 @@
       "version": "10.1.1",
       "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-10.1.1.tgz",
       "integrity": "sha512-9zC0sdhQljUeMr2yQ7o4kzEZXVAy82fFOAZE1+TwPL7qR0b0sphe7OJ5T1GX1qLcwuVaJ8YewaPoLSHRk79+Rg==",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-location": {
+      "version": "14.2.2",
+      "resolved": "https://registry.npmjs.org/expo-location/-/expo-location-14.2.2.tgz",
+      "integrity": "sha512-P1v+huBWhuerV4okRhN0+Htx3Nw8LGWTUF66E5iwuZEWvLTYQEQ+Od0j2CvD4FY6rhncNpoIZcWVlIy5NmG4fg==",
+      "dependencies": {
+        "@expo/config-plugins": "^4.0.14"
+      },
       "peerDependencies": {
         "expo": "*"
       }
@@ -29510,6 +29522,14 @@
       "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-10.1.1.tgz",
       "integrity": "sha512-9zC0sdhQljUeMr2yQ7o4kzEZXVAy82fFOAZE1+TwPL7qR0b0sphe7OJ5T1GX1qLcwuVaJ8YewaPoLSHRk79+Rg==",
       "requires": {}
+    },
+    "expo-location": {
+      "version": "14.2.2",
+      "resolved": "https://registry.npmjs.org/expo-location/-/expo-location-14.2.2.tgz",
+      "integrity": "sha512-P1v+huBWhuerV4okRhN0+Htx3Nw8LGWTUF66E5iwuZEWvLTYQEQ+Od0j2CvD4FY6rhncNpoIZcWVlIy5NmG4fg==",
+      "requires": {
+        "@expo/config-plugins": "^4.0.14"
+      }
     },
     "expo-modules-autolinking": {
       "version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "react-native-webview": "11.18.1",
     "webpack-dev-server": "~3.11.0",
     "expo-constants": "~13.1.1",
-    "@react-native-async-storage/async-storage": "~1.17.3"
+    "@react-native-async-storage/async-storage": "~1.17.3",
+    "expo-location": "~14.2.2"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/src/hooks/useForeGroundLocation.js
+++ b/src/hooks/useForeGroundLocation.js
@@ -1,0 +1,43 @@
+import { useState, useEffect } from "react";
+import * as Location from "expo-location";
+
+const SEOUL_STATION_COORDINATES = JSON.stringify({
+  longitude: 37.5559,
+  latitude: 126.9723,
+});
+
+function useForeGroundLocation() {
+  const [location, setLocation] = useState();
+  const [error, setError] = useState();
+
+  useEffect(() => {
+    const requestLocation = async () => {
+      const { status } = await Location.requestForegroundPermissionsAsync();
+
+      if (status !== "granted") {
+        return setError("위치 권한 요청이 거부되었습니다.");
+      }
+
+      const location = await Location.getCurrentPositionAsync({});
+
+      const coordinates = JSON.stringify({
+        longitude: location.coords.longitude,
+        latitude: location.coords.latitude,
+      });
+
+      setLocation(coordinates);
+    };
+
+    requestLocation();
+  }, []);
+
+  useEffect(() => {
+    if (error) {
+      setLocation(SEOUL_STATION_COORDINATES);
+    }
+  }, [error]);
+
+  return { location };
+}
+
+export default useForeGroundLocation;

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -2,12 +2,23 @@ import { useRef } from "react";
 import { WebView } from "react-native-webview";
 
 import Screen from "../components/Screen";
+import useForeGroundLocation from "../hooks/useForeGroundLocation";
 import useToken from "../hooks/useToken";
 
 function HomeScreen() {
   const webviewRef = useRef();
 
   const { script, setToken } = useToken();
+  const { location } = useForeGroundLocation();
+
+  if (location) {
+    const script = `
+      window.coords = "${location}";
+      true;
+    `;
+
+    webviewRef.current.injectJavaScript(script);
+  }
 
   const handleMessage = ({ nativeEvent }) => {
     const messageFromWebView = nativeEvent.data;

--- a/src/services/integration.js
+++ b/src/services/integration.js
@@ -3,9 +3,7 @@ class IntegrationService {
     this.storage = storage;
   }
 
-  getTokenFromStorage = async () => {
-    return await this.storage.getItem("token");
-  };
+  getTokenFromStorage = async () => await this.storage.getItem("token");
 
   setTokenToStorage = async (token) => {
     await this.storage.setItem("token", token);


### PR DESCRIPTION
## 설명

사용자에게 앱을 사용하는 동안 핸드폰의 위치를 추적할 권한을 요청하고, 얻은 위치를 웹뷰에 주입하는 Custom Hook 을 제작했습니다.

만약 사용자가 권한 부여를 거부한다면 서울역의 좌표를 웹뷰에 주입하도록 했습니다.

## 변경 또는 추가한 로직
설치한 라이브러리:
1. expo-location - Expo 에서 사용자의 위치 권한 요청을 쉽게 요청하도록 만든 라이브러리.

[칸반 카드](https://www.notion.so/vanillacoding/d507ae7e90094ed79f094ce86e488b5c?v=78859dbad7f04cf8a61d32359cb6b0b3&p=1f33a695cfa24d3fb1ab06c3a86d08a0)