### PR TITLE
이미지 첨부 기능 및 토큰 저장 로직 수정

### DIFF
--- a/app.json
+++ b/app.json
@@ -9,7 +9,7 @@
     "splash": {
       "image": "./assets/splash.png",
       "resizeMode": "contain",
-      "backgroundColor": "#ffffff"
+      "backgroundColor": "#000000"
     },
     "updates": {
       "fallbackToCacheTimeout": 0

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@react-navigation/native": "^6.0.10",
         "expo": "~45.0.0",
         "expo-constants": "~13.1.1",
+        "expo-image-picker": "~13.1.1",
         "expo-location": "~14.2.2",
         "expo-status-bar": "~1.3.0",
         "react": "17.0.2",
@@ -9828,6 +9829,35 @@
       },
       "peerDependencies": {
         "expo": "*"
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-3.2.0.tgz",
+      "integrity": "sha512-LU3Q2prn64/HxdToDmxgMIRXS1ZvD9Q3iCxRVTZn1fPQNNDciIQFE5okaa74Ogx20DFHs90r6WoUd7w9Af1OGQ==",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-13.1.1.tgz",
+      "integrity": "sha512-fU8oONRkKg5DvuU+7KvnuOtf1ubzXNU/OsE/T6yB149LbXb+ZN5A49NicvJ+cOG4Oa5NAnILt0aAAkchIr3iRQ==",
+      "dependencies": {
+        "@expo/config-plugins": "^4.0.14",
+        "expo-image-loader": "~3.2.0",
+        "uuid": "7.0.2"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker/node_modules/uuid": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.2.tgz",
+      "integrity": "sha512-vy9V/+pKG+5ZTYKf+VcphF5Oc6EFiu3W8Nv3P3zIh0EqVI80ZxOzuPfe9EHjkFNvf8+xuTHVeei4Drydlx4zjw==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/expo-keep-awake": {
@@ -29515,6 +29545,29 @@
       "integrity": "sha512-vmhzpE95Ym4iOj8IELof+C/3Weert2B3LyxV5rBjGosjzBdov+o+S6b5mN7Yc9kyEGykwB6k7npL45X3hFYDQA==",
       "requires": {
         "fontfaceobserver": "^2.1.0"
+      }
+    },
+    "expo-image-loader": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-3.2.0.tgz",
+      "integrity": "sha512-LU3Q2prn64/HxdToDmxgMIRXS1ZvD9Q3iCxRVTZn1fPQNNDciIQFE5okaa74Ogx20DFHs90r6WoUd7w9Af1OGQ==",
+      "requires": {}
+    },
+    "expo-image-picker": {
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-13.1.1.tgz",
+      "integrity": "sha512-fU8oONRkKg5DvuU+7KvnuOtf1ubzXNU/OsE/T6yB149LbXb+ZN5A49NicvJ+cOG4Oa5NAnILt0aAAkchIr3iRQ==",
+      "requires": {
+        "@expo/config-plugins": "^4.0.14",
+        "expo-image-loader": "~3.2.0",
+        "uuid": "7.0.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.2.tgz",
+          "integrity": "sha512-vy9V/+pKG+5ZTYKf+VcphF5Oc6EFiu3W8Nv3P3zIh0EqVI80ZxOzuPfe9EHjkFNvf8+xuTHVeei4Drydlx4zjw=="
+        }
       }
     },
     "expo-keep-awake": {

--- a/package.json
+++ b/package.json
@@ -12,9 +12,12 @@
   },
   "dependencies": {
     "@expo/webpack-config": "~0.16.2",
+    "@react-native-async-storage/async-storage": "~1.17.3",
     "@react-navigation/bottom-tabs": "^6.3.1",
     "@react-navigation/native": "^6.0.10",
     "expo": "~45.0.0",
+    "expo-constants": "~13.1.1",
+    "expo-location": "~14.2.2",
     "expo-status-bar": "~1.3.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",
@@ -22,9 +25,7 @@
     "react-native-web": "0.17.7",
     "react-native-webview": "11.18.1",
     "webpack-dev-server": "~3.11.0",
-    "expo-constants": "~13.1.1",
-    "@react-native-async-storage/async-storage": "~1.17.3",
-    "expo-location": "~14.2.2"
+    "expo-image-picker": "~13.1.1"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/src/hooks/useForeGroundLocation.js
+++ b/src/hooks/useForeGroundLocation.js
@@ -1,14 +1,15 @@
 import { useState, useEffect } from "react";
 import * as Location from "expo-location";
 
-const SEOUL_STATION_COORDINATES = JSON.stringify({
+const SEOUL_STATION_COORDINATES = {
   longitude: 37.5559,
   latitude: 126.9723,
-});
+};
 
 function useForeGroundLocation() {
-  const [location, setLocation] = useState();
-  const [error, setError] = useState();
+  const [longitude, setLongitude] = useState("");
+  const [latitude, setLatitude] = useState("");
+  const [error, setError] = useState("");
 
   useEffect(() => {
     const requestLocation = async () => {
@@ -20,12 +21,8 @@ function useForeGroundLocation() {
 
       const location = await Location.getCurrentPositionAsync({});
 
-      const coordinates = JSON.stringify({
-        longitude: location.coords.longitude,
-        latitude: location.coords.latitude,
-      });
-
-      setLocation(coordinates);
+      setLongitude(location.coords.longitude);
+      setLatitude(location.coords.latitude);
     };
 
     requestLocation();
@@ -33,11 +30,12 @@ function useForeGroundLocation() {
 
   useEffect(() => {
     if (error) {
-      setLocation(SEOUL_STATION_COORDINATES);
+      setLongitude(SEOUL_STATION_COORDINATES.longitude);
+      setLatitude(SEOUL_STATION_COORDINATES.latitude);
     }
   }, [error]);
 
-  return { location };
+  return { longitude, latitude };
 }
 
 export default useForeGroundLocation;

--- a/src/hooks/useToken.js
+++ b/src/hooks/useToken.js
@@ -26,6 +26,11 @@ function useToken() {
   useEffect(() => {
     if (token) {
       Storage.setTokenToStorage(token);
+      setScript(`
+        window.isNativeApp = true;
+        window.token = "${token}";
+        true;
+      `);
     }
   }, [token]);
 

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -1,5 +1,6 @@
-import { useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { WebView } from "react-native-webview";
+import * as ImagePicker from "expo-image-picker";
 
 import Screen from "../components/Screen";
 import useForeGroundLocation from "../hooks/useForeGroundLocation";
@@ -8,17 +9,24 @@ import useToken from "../hooks/useToken";
 function HomeScreen() {
   const webviewRef = useRef();
 
+  const [base64, setBase64] = useState("");
+
   const { script, setToken } = useToken();
-  const { location } = useForeGroundLocation();
+  const { longitude, latitude } = useForeGroundLocation();
 
-  if (location) {
-    const script = `
-      window.coords = "${location}";
-      true;
-    `;
+  const pickImage = async () => {
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      allowsEditing: true,
+      aspect: [3, 4],
+      quality: 0.3,
+      base64: true,
+    });
 
-    webviewRef.current.injectJavaScript(script);
-  }
+    if (!result.cancelled) {
+      setBase64(result.base64);
+    }
+  };
 
   const handleMessage = ({ nativeEvent }) => {
     const messageFromWebView = nativeEvent.data;
@@ -26,9 +34,32 @@ function HomeScreen() {
     if (messageFromWebView.includes("token")) {
       const token = messageFromWebView.split(" ")[1];
 
-      setToken(token);
+      return setToken(token);
+    }
+
+    if (messageFromWebView === "open gallery") {
+      pickImage();
     }
   };
+
+  useEffect(() => {
+    webviewRef.current.injectJavaScript(script);
+  }, [script]);
+
+  useEffect(() => {
+    webviewRef.current.injectJavaScript(`
+      window.longitude = "${longitude}";
+      window.latitude = "${latitude}";
+      true;
+    `);
+  }, [longitude, latitude]);
+
+  useEffect(() => {
+    webviewRef.current.injectJavaScript(`
+      window.base64 = "${base64}";
+      true;
+    `);
+  }, [base64]);
 
   return (
     <Screen>


### PR DESCRIPTION
## 설명

웹뷰에서 버튼을 클릭하면 네이티브의 갤러리가 열리고, 선택한 사진을 base64 문자열로 변환해 웹뷰에 주입해주는 로직을 완성했습니다.

Home Screen 에서 토큰, 위치, 이미지 상태 변화에 대응하는 로직을 정리했습니다.

그리고 스플래시 스크린의 배경화면을 검은색으로 바꿨습니다 ㅎㅎ

## 변경 또는 추가한 로직

설치한 라이브러리:
1. expo-image-picker - expo-image-crop-picker 와 비교하다가 네이티브 코드 수정이 필요 없는 지금의 라이브러리를 선택했습니다. 우리 프로젝트는 Expo managed 로 제작했기 때문에 네이티브 코드를 수정하기가 어렵습니다.
