### PR TITLE
feat: 채팅창 네이티브 구현 완료 및 환경변수 설정

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,8 @@
   "extends": [
     "eslint:recommended",
     "plugin:react/recommended",
-    "plugin:prettier/recommended"
+    "plugin:prettier/recommended",
+    "plugin:react-hooks/recommended"
   ],
   "parserOptions": {
     "ecmaFeatures": {

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ web-build/
 .DS_Store
 
 .env
+
+secrets.js

--- a/App.js
+++ b/App.js
@@ -2,8 +2,8 @@ import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import { NavigationContainer } from "@react-navigation/native";
 
 import HomeScreen from "./src/screens/HomeScreen";
-import ChatListScreen from "./src/screens/ChatListScreen";
-import ProfileScreen from "./src/screens/ProfileScreen";
+import ChatListStackNavigator from "./src/navigation/StackNavigation";
+import ProfileStackNavigator from "./src/navigation/ProfileStackNavigation";
 
 const Tab = createBottomTabNavigator();
 
@@ -12,8 +12,8 @@ export default function App() {
     <NavigationContainer>
       <Tab.Navigator screenOptions={{ headerShown: false }}>
         <Tab.Screen name="Home" component={HomeScreen} />
-        <Tab.Screen name="ChatList" component={ChatListScreen} />
-        <Tab.Screen name="Profile" component={ProfileScreen} />
+        <Tab.Screen name="ChatStack" component={ChatListStackNavigator} />
+        <Tab.Screen name="ProfileStack" component={ProfileStackNavigator} />
       </Tab.Navigator>
     </NavigationContainer>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,9 @@
         "@react-native-async-storage/async-storage": "~1.17.3",
         "@react-navigation/bottom-tabs": "^6.3.1",
         "@react-navigation/native": "^6.0.10",
+        "@react-navigation/native-stack": "^6.6.2",
+        "axios": "^0.27.2",
+        "dayjs": "^1.11.3",
         "expo": "~45.0.0",
         "expo-constants": "~13.1.1",
         "expo-image-picker": "~13.1.1",
@@ -22,6 +25,7 @@
         "react-native": "0.68.2",
         "react-native-web": "0.17.7",
         "react-native-webview": "11.18.1",
+        "socket.io-client": "^4.5.1",
         "webpack-dev-server": "~3.11.0"
       },
       "devDependencies": {
@@ -30,6 +34,7 @@
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.30.0",
+        "eslint-plugin-react-hooks": "^4.6.0",
         "husky": "^8.0.1",
         "lint-staged": "^13.0.0",
         "prettier": "^2.6.2"
@@ -5234,6 +5239,22 @@
         "react-native": "*"
       }
     },
+    "node_modules/@react-navigation/native-stack": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native-stack/-/native-stack-6.6.2.tgz",
+      "integrity": "sha512-pFMuzhxbPml5MBvJVAzHWoaUkQaefAOKpuUnAs/AxNQuHQwwnxRmDit1PQLuIPo7g7DlfwFXagDHE1R0tbnS8Q==",
+      "dependencies": {
+        "@react-navigation/elements": "^1.3.3",
+        "warn-once": "^0.1.0"
+      },
+      "peerDependencies": {
+        "@react-navigation/native": "^6.0.0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-safe-area-context": ">= 3.0.0",
+        "react-native-screens": ">= 3.0.0"
+      }
+    },
     "node_modules/@react-navigation/native/node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -5279,6 +5300,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
+      "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
     },
     "node_modules/@types/glob": {
       "version": "7.2.0",
@@ -6079,6 +6105,28 @@
       },
       "engines": {
         "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/babel-core": {
@@ -8284,9 +8332,9 @@
       "integrity": "sha512-+LSAiGFwQ9dRnRdOeaj7g47ZFJcOUPukAP8J3A3fuZ1g9Y44BG+P1sgApjLXTQPOzC4+7S9Wr8kXsfpINM4jpw=="
     },
     "node_modules/dayjs": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.2.tgz",
-      "integrity": "sha512-F4LXf1OeU9hrSYRPTTj/6FbO4HTjPKXvEIC1P2kcnFurViINCVk3ZV0xAS3XVx9MkMsXbbqlK6hjseaYbgKEHw=="
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.3.tgz",
+      "integrity": "sha512-xxwlswWOlGhzgQ4TKzASQkUhqERI3egRNqgV4ScR8wlANA/A9tZ7miXa44vTTKEq5l7vWoL5G57bG3zA+Kow0A=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -8800,6 +8848,46 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/engine.io-client": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.2.2.tgz",
+      "integrity": "sha512-8ZQmx0LQGRTYkHuogVZuGSpDqYZtCM/nv8zQ68VZ+JkOpazJ7ICdsSpaO6iXwvaU30oFg5QJOJWj8zWqhbKjkQ==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.0.3",
+        "ws": "~8.2.3",
+        "xmlhttprequest-ssl": "~2.0.0"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/ws": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.4.tgz",
+      "integrity": "sha512-+nVFp+5z1E3HcToEnO7ZIj3g+3k9389DvWtvJZz0T6/eOCPIyyxehFcedoYrZQrp0LgQbD9pPXhpMBKMd5QURg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
@@ -9094,6 +9182,18 @@
       },
       "peerDependencies": {
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
+      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/doctrine": {
@@ -11882,15 +11982,6 @@
       },
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/immer": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
-      "integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-fresh": {
@@ -17257,6 +17348,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/react-dev-utils/node_modules/immer": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
+      "integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/react-dev-utils/node_modules/loader-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
@@ -18793,6 +18893,32 @@
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/socket.io-client": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.5.1.tgz",
+      "integrity": "sha512-e6nLVgiRYatS+AHXnOnGi4ocOpubvOUCGhyWw8v+/FxW8saHkinG6Dfhi9TU0Kt/8mwJIAASxvw6eujQmjdZVA==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.2.1",
+        "socket.io-parser": "~4.2.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.0.tgz",
+      "integrity": "sha512-tLfmEwcEwnlQTxFB7jibL/q2+q8dlVQzj4JdRLJ/W/G1+Fu9VSxCx1Lo+n1HvXxKnM//dUuD0xgiA7tQf57Vng==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/sockjs": {
@@ -21966,6 +22092,14 @@
       "integrity": "sha512-ruPC/fyPNck2BD1dpz0AZZyrEwMOrWTO5lDdIXS91rs3wtm4j+T8Rp2o+zoOYkkAxJTZRPOSnOGei1egoRmKMQ==",
       "dependencies": {
         "sax": "^1.2.1"
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
+      "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/xtend": {
@@ -25938,6 +26072,15 @@
         }
       }
     },
+    "@react-navigation/native-stack": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native-stack/-/native-stack-6.6.2.tgz",
+      "integrity": "sha512-pFMuzhxbPml5MBvJVAzHWoaUkQaefAOKpuUnAs/AxNQuHQwwnxRmDit1PQLuIPo7g7DlfwFXagDHE1R0tbnS8Q==",
+      "requires": {
+        "@react-navigation/elements": "^1.3.3",
+        "warn-once": "^0.1.0"
+      }
+    },
     "@react-navigation/routers": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@react-navigation/routers/-/routers-6.1.0.tgz",
@@ -25972,6 +26115,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
+    },
+    "@socket.io/component-emitter": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
+      "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
     },
     "@types/glob": {
       "version": "7.2.0",
@@ -26656,6 +26804,27 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+    },
+    "axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "requires": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "babel-core": {
       "version": "7.0.0-bridge.0",
@@ -28368,9 +28537,9 @@
       "integrity": "sha512-+LSAiGFwQ9dRnRdOeaj7g47ZFJcOUPukAP8J3A3fuZ1g9Y44BG+P1sgApjLXTQPOzC4+7S9Wr8kXsfpINM4jpw=="
     },
     "dayjs": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.2.tgz",
-      "integrity": "sha512-F4LXf1OeU9hrSYRPTTj/6FbO4HTjPKXvEIC1P2kcnFurViINCVk3ZV0xAS3XVx9MkMsXbbqlK6hjseaYbgKEHw=="
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.3.tgz",
+      "integrity": "sha512-xxwlswWOlGhzgQ4TKzASQkUhqERI3egRNqgV4ScR8wlANA/A9tZ7miXa44vTTKEq5l7vWoL5G57bG3zA+Kow0A=="
     },
     "debug": {
       "version": "4.3.4",
@@ -28780,6 +28949,31 @@
       "requires": {
         "once": "^1.4.0"
       }
+    },
+    "engine.io-client": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.2.2.tgz",
+      "integrity": "sha512-8ZQmx0LQGRTYkHuogVZuGSpDqYZtCM/nv8zQ68VZ+JkOpazJ7ICdsSpaO6iXwvaU30oFg5QJOJWj8zWqhbKjkQ==",
+      "requires": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.0.3",
+        "ws": "~8.2.3",
+        "xmlhttprequest-ssl": "~2.0.0"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "8.2.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+          "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+          "requires": {}
+        }
+      }
+    },
+    "engine.io-parser": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.4.tgz",
+      "integrity": "sha512-+nVFp+5z1E3HcToEnO7ZIj3g+3k9389DvWtvJZz0T6/eOCPIyyxehFcedoYrZQrp0LgQbD9pPXhpMBKMd5QURg=="
     },
     "enhanced-resolve": {
       "version": "4.5.0",
@@ -29215,6 +29409,13 @@
           }
         }
       }
+    },
+    "eslint-plugin-react-hooks": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
+      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+      "dev": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "4.0.3",
@@ -31114,11 +31315,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.6.3.tgz",
       "integrity": "sha512-47xSUiQioGaB96nqtp5/q55m0aBQSQdyIloMOc/x+QVTDZLNmXE892IIDrJ0hM1A5vcNUDD5tDffkSP5lCaIIA=="
-    },
-    "immer": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
-      "integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA=="
     },
     "import-fresh": {
       "version": "2.0.0",
@@ -35282,6 +35478,11 @@
             "slash": "^3.0.0"
           }
         },
+        "immer": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
+          "integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA=="
+        },
         "loader-utils": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
@@ -36503,6 +36704,26 @@
             "is-buffer": "^1.1.5"
           }
         }
+      }
+    },
+    "socket.io-client": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.5.1.tgz",
+      "integrity": "sha512-e6nLVgiRYatS+AHXnOnGi4ocOpubvOUCGhyWw8v+/FxW8saHkinG6Dfhi9TU0Kt/8mwJIAASxvw6eujQmjdZVA==",
+      "requires": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.2.1",
+        "socket.io-parser": "~4.2.0"
+      }
+    },
+    "socket.io-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.0.tgz",
+      "integrity": "sha512-tLfmEwcEwnlQTxFB7jibL/q2+q8dlVQzj4JdRLJ/W/G1+Fu9VSxCx1Lo+n1HvXxKnM//dUuD0xgiA7tQf57Vng==",
+      "requires": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
       }
     },
     "sockjs": {
@@ -39017,6 +39238,11 @@
       "requires": {
         "sax": "^1.2.1"
       }
+    },
+    "xmlhttprequest-ssl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
+      "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,12 @@
     "@react-native-async-storage/async-storage": "~1.17.3",
     "@react-navigation/bottom-tabs": "^6.3.1",
     "@react-navigation/native": "^6.0.10",
+    "@react-navigation/native-stack": "^6.6.2",
+    "axios": "^0.27.2",
+    "dayjs": "^1.11.3",
     "expo": "~45.0.0",
     "expo-constants": "~13.1.1",
+    "expo-image-picker": "~13.1.1",
     "expo-location": "~14.2.2",
     "expo-status-bar": "~1.3.0",
     "react": "17.0.2",
@@ -24,8 +28,8 @@
     "react-native": "0.68.2",
     "react-native-web": "0.17.7",
     "react-native-webview": "11.18.1",
-    "webpack-dev-server": "~3.11.0",
-    "expo-image-picker": "~13.1.1"
+    "socket.io-client": "^4.5.1",
+    "webpack-dev-server": "~3.11.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",
@@ -33,6 +37,7 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.30.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
     "husky": "^8.0.1",
     "lint-staged": "^13.0.0",
     "prettier": "^2.6.2"

--- a/src/hooks/useToken.js
+++ b/src/hooks/useToken.js
@@ -49,7 +49,7 @@ function useToken() {
     }
   }, [token]);
 
-  return { script, setToken };
+  return { script, setToken, token };
 }
 
 export default useToken;

--- a/src/navigation/ProfileStackNavigation.js
+++ b/src/navigation/ProfileStackNavigation.js
@@ -1,0 +1,23 @@
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+
+import ChatRoomScreen from "../screens/ChatRoomScreen";
+import ProfileScreen from "../screens/ProfileScreen";
+
+const Stack = createNativeStackNavigator();
+
+const ProfileStackNavigator = () => (
+  <Stack.Navigator>
+    <Stack.Screen
+      name="ChatList"
+      component={ProfileScreen}
+      options={{ headerShown: false }}
+    />
+    <Stack.Screen
+      name="ChatRoom"
+      component={ChatRoomScreen}
+      options={{ headerShown: false }}
+    />
+  </Stack.Navigator>
+);
+
+export default ProfileStackNavigator;

--- a/src/navigation/StackNavigation.js
+++ b/src/navigation/StackNavigation.js
@@ -1,0 +1,23 @@
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+
+import ChatListScreen from "../screens/ChatListScreen";
+import ChatRoomScreen from "../screens/ChatRoomScreen";
+
+const Stack = createNativeStackNavigator();
+
+const ChatListStackNavigator = () => (
+  <Stack.Navigator>
+    <Stack.Screen
+      name="ChatList"
+      component={ChatListScreen}
+      options={{ headerShown: false }}
+    />
+    <Stack.Screen
+      name="ChatRoom"
+      component={ChatRoomScreen}
+      options={{ headerShown: false }}
+    />
+  </Stack.Navigator>
+);
+
+export default ChatListStackNavigator;

--- a/src/screens/ChatListScreen.js
+++ b/src/screens/ChatListScreen.js
@@ -1,12 +1,17 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { BackHandler } from "react-native";
 import { WebView } from "react-native-webview";
 
+import getEnvVars from "../../secrets";
 import Screen from "../components/Screen";
 import useToken from "../hooks/useToken";
 
-function ChatListScreen() {
+const { CHAT_SCREEN_URL } = getEnvVars();
+
+function ChatListScreen({ navigation }) {
   const webviewRef = useRef();
+
+  const [navState, setNavState] = useState({});
 
   const { script, setToken } = useToken();
 
@@ -18,6 +23,22 @@ function ChatListScreen() {
 
       return setToken(token);
     }
+
+    if (messageFromWebView === "navigationStateChange") {
+      return setNavState(nativeEvent);
+    }
+
+    const parsedMessage = JSON.parse(messageFromWebView);
+
+    if (parsedMessage.type === "CHATROOM") {
+      navigation.navigate("ChatRoom", {
+        userId: parsedMessage.userId,
+        roomId: parsedMessage.roomId,
+        friendId: parsedMessage.friendId,
+        friendImage: parsedMessage.friendImage,
+        friendName: parsedMessage.friendName,
+      });
+    }
   };
 
   useEffect(() => {
@@ -26,7 +47,7 @@ function ChatListScreen() {
 
   useEffect(() => {
     const handleBackButtonPress = () => {
-      if (webviewRef.current) {
+      if (webviewRef.current && navState.canGoBack) {
         webviewRef.current.goBack();
         return true;
       }
@@ -41,15 +62,16 @@ function ChatListScreen() {
         "hardwareBackPress",
         handleBackButtonPress
       );
-  }, []);
+  }, [navState.canGoBack]);
 
   return (
     <Screen>
       <WebView
-        source={{ uri: "https://cosmic-semolina-b6e8c3.netlify.app" }}
+        source={{ uri: CHAT_SCREEN_URL }}
         ref={webviewRef}
         onMessage={handleMessage}
         injectedJavaScript={script}
+        onNavigationStateChange={setNavState}
       />
     </Screen>
   );

--- a/src/screens/ChatRoomScreen.js
+++ b/src/screens/ChatRoomScreen.js
@@ -1,0 +1,219 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import axios from "axios";
+import { useEffect, useState } from "react";
+import {
+  FlatList,
+  Image,
+  Text,
+  View,
+  StyleSheet,
+  TextInput,
+  TouchableOpacity,
+} from "react-native";
+import io from "socket.io-client/dist/socket.io";
+
+import getEnvVars from "../../secrets";
+import dayjs from "../services/time";
+import Screen from "../components/Screen";
+import IntegrationService from "../services/integration";
+import ApiService from "../services/Api";
+
+const { SERVER_URL } = getEnvVars();
+
+const ApiInstance = new ApiService(axios);
+const Storage = new IntegrationService(AsyncStorage);
+
+const socket = io(SERVER_URL, { jsonp: false });
+
+function ChatRoomScreen({ route }) {
+  const { userId, roomId, friendId, friendImage, friendName } = route.params;
+
+  const [input, setInput] = useState("");
+  const [chats, setChats] = useState([]);
+  const [error, setError] = useState("");
+  const [friendInfoAsync, setFriendInfoAsync] = useState({
+    name: "",
+    image: "",
+  });
+
+  useEffect(() => {
+    const requestFriendInfo = async (id) => {
+      const token = await Storage.getTokenFromStorage();
+
+      const { data } = await ApiInstance.getFriendInfo(id, token)().catch((e) =>
+        setError(JSON.stringify(e))
+      );
+
+      if (!data.success) {
+        return setError(data.message);
+      }
+
+      const friend = {
+        name: data.user.name,
+        image: data.user.image,
+      };
+
+      setFriendInfoAsync(friend);
+    };
+
+    if (!friendImage || !friendName) {
+      requestFriendInfo(friendId);
+    }
+  }, [friendId, friendImage, friendName]);
+
+  useEffect(() => {
+    socket.connect();
+
+    socket.emit("joinRoom", roomId);
+
+    socket.on("joinedRoom", (chatHistory) => {
+      setChats(chatHistory);
+    });
+
+    socket.on("chat-broadcast", (chat) => {
+      setChats((prev) => [...prev, chat]);
+    });
+
+    socket.on("error", (error) => {
+      setError(error);
+    });
+
+    return () => socket.close();
+  }, [roomId]);
+
+  const send = () => {
+    const chat = {
+      id: userId,
+      text: input,
+      createdAt: new Date(),
+    };
+
+    setChats((prev) => [...prev, chat]);
+
+    delete chat.createdAt;
+
+    socket.emit("chat", chat);
+    setInput("");
+  };
+
+  return (
+    <Screen>
+      <View style={styles.thumbnailContainer}>
+        <Image
+          source={{ uri: friendImage || friendInfoAsync.image }}
+          style={styles.thumbnail}
+        />
+        <Text style={styles.thumbnailText} numberOfLines={1}>
+          {friendName || friendInfoAsync.name}
+        </Text>
+        <Text>{error}</Text>
+      </View>
+      <View style={styles.messages}>
+        <FlatList
+          data={chats.slice().reverse()}
+          keyExtractor={(chat) => chat.createdAt}
+          inverted
+          renderItem={({ item: chat }) => (
+            <View
+              style={
+                chat.id === friendId
+                  ? styles.friendMessageBox
+                  : styles.myMessageBox
+              }
+            >
+              <Text>{chat.text}</Text>
+              <Text
+                style={chat.id === friendId ? styles.friendText : styles.myText}
+              >
+                {dayjs(chat.createdAt).format("L LT")}
+              </Text>
+            </View>
+          )}
+        />
+        <View style={styles.inputContainer}>
+          <TextInput
+            style={styles.input}
+            placeholder="메시지를 입력해 주세요"
+            onChangeText={setInput}
+            value={input}
+          />
+          <TouchableOpacity onPress={send} style={styles.touchable}>
+            <View style={styles.button}>
+              <Text style={styles.buttonText}>Send</Text>
+            </View>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Screen>
+  );
+}
+
+const styles = StyleSheet.create({
+  thumbnailContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    padding: 15,
+  },
+  thumbnail: {
+    width: 50,
+    height: 50,
+    borderRadius: 25,
+    marginRight: 15,
+  },
+  thumbnailText: {
+    fontSize: 18,
+    fontWeight: "600",
+  },
+  messages: {
+    flex: 1,
+    padding: 15,
+  },
+  friendMessageBox: {
+    padding: 10,
+    borderRadius: 5,
+    backgroundColor: "#eaeaea",
+    marginVertical: 5,
+    marginRight: 100,
+  },
+  myMessageBox: {
+    padding: 10,
+    borderRadius: 5,
+    backgroundColor: "#d1ecc8",
+    marginVertical: 5,
+    marginLeft: 100,
+  },
+  friendText: {
+    alignSelf: "flex-start",
+    color: "grey",
+  },
+  myText: {
+    alignSelf: "flex-end",
+    color: "grey",
+  },
+  inputContainer: {
+    flexDirection: "row",
+  },
+  input: {
+    backgroundColor: "#eaeaea",
+    height: 50,
+    borderRadius: 5,
+    width: "80%",
+    paddingHorizontal: 25,
+    marginRight: 10,
+  },
+  touchable: {
+    backgroundColor: "#d1ecc8",
+    flex: 1,
+    width: "100%",
+    justifyContent: "center",
+    borderRadius: 5,
+  },
+  button: {
+    alignItems: "center",
+  },
+  buttonText: {
+    color: "#55734a",
+  },
+});
+
+export default ChatRoomScreen;

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -3,9 +3,12 @@ import { WebView } from "react-native-webview";
 import * as ImagePicker from "expo-image-picker";
 import { BackHandler } from "react-native";
 
+import getEnvVars from "../../secrets";
 import Screen from "../components/Screen";
 import useForeGroundLocation from "../hooks/useForeGroundLocation";
 import useToken from "../hooks/useToken";
+
+const { HOME_SCREEN_URL } = getEnvVars();
 
 function HomeScreen() {
   const webviewRef = useRef();
@@ -90,7 +93,7 @@ function HomeScreen() {
     <Screen>
       <WebView
         source={{
-          uri: "http://192.168.0.29:3000/",
+          uri: HOME_SCREEN_URL,
         }}
         ref={webviewRef}
         onMessage={handleMessage}

--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -1,12 +1,17 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { BackHandler } from "react-native";
 import { WebView } from "react-native-webview";
 
+import getEnvVars from "../../secrets";
 import Screen from "../components/Screen";
 import useToken from "../hooks/useToken";
 
-function ProfileScreen() {
+const { PROFILE_SCREEN_URL } = getEnvVars();
+
+function ProfileScreen({ navigation }) {
   const webviewRef = useRef();
+
+  const [navState, setNavState] = useState({});
 
   const { script, setToken } = useToken();
 
@@ -18,11 +23,25 @@ function ProfileScreen() {
 
       return setToken(token);
     }
+
+    if (messageFromWebView === "navigationStateChange") {
+      return setNavState(nativeEvent);
+    }
+
+    const parsedMessage = JSON.parse(messageFromWebView);
+
+    if (parsedMessage.type === "CHATROOM_FROM_PROFILE") {
+      navigation.navigate("ChatRoom", {
+        userId: parsedMessage.userId,
+        roomId: parsedMessage.roomId,
+        friendId: parsedMessage.friendId,
+      });
+    }
   };
 
   useEffect(() => {
     const handleBackButtonPress = () => {
-      if (webviewRef.current) {
+      if (webviewRef.current && navState.canGoBack) {
         webviewRef.current.goBack();
         return true;
       }
@@ -37,15 +56,16 @@ function ProfileScreen() {
         "hardwareBackPress",
         handleBackButtonPress
       );
-  }, []);
+  }, [navState.canGoBack]);
 
   return (
     <Screen>
       <WebView
-        source={{ uri: "http://192.168.0.29:3001/" }}
+        source={{ uri: PROFILE_SCREEN_URL }}
         ref={webviewRef}
         onMessage={handleMessage}
         injectedJavaScript={script}
+        onNavigationStateChange={setNavState}
       />
     </Screen>
   );

--- a/src/services/Api.js
+++ b/src/services/Api.js
@@ -1,0 +1,21 @@
+import getEnvVars from "../../secrets";
+
+const { SERVER_URL } = getEnvVars();
+
+class ApiService {
+  constructor(axios) {
+    this.API = axios.create({
+      baseURL: `${SERVER_URL}`,
+      timeout: 5000,
+    });
+  }
+
+  getFriendInfo = (friendId, JWT) => async () =>
+    await this.API.get(`/user/${friendId}/chat-info`, {
+      headers: {
+        Authorization: `Bearer ${JWT}`,
+      },
+    });
+}
+
+export default ApiService;

--- a/src/services/time.js
+++ b/src/services/time.js
@@ -1,0 +1,6 @@
+import dayjs from "dayjs";
+import localizedFormat from "dayjs/plugin/localizedFormat";
+
+dayjs.extend(localizedFormat);
+
+export default dayjs;


### PR DESCRIPTION
## 설명

웹뷰에서 소켓을 쓸 수 없다는 사실을 뒤늦게 알게되어 급하게 채팅창을 네이티브로 구현하기로 했습니다.
웹뷰에서 입장하길 원하는 채팅방을 클릭하면 네이티브의 Stack Navigation 스크린이 나타나고, 웹뷰에서 받은 정보로 소켓에 입장합니다.

위 기능은 chat, profile 탭 모두에서 동작해야 하기 때문에 chat, profile 탭을 각각 원래의 스크린과 네이티브 채팅 스크린을 담은 Stack Navigator 로 바꿔주었습니다.

환경 변수 설정은,
리액트 네이티브에서는 일반적으로 .env 파일을 만들어서 환경변수를 하지 않는다는 사실을 알게 되었습니다.
그래서 [이 블로그 글](https://alxmrtnz.com/thoughts/2019/03/12/environment-variables-and-workflow-in-expo.html)을 참고하여 배포시 숨겨야 할 정보들을 환경변수로 만들었습니다.

다음 Pull 받으실 때 최상단 디렉토리에 `secrets.js` 라는 파일을 만들고 아래의 코드를 붙여넣어 주세요.
```
/* eslint-disable no-undef */
import Constants from "expo-constants";

const DEV_HOME_SCREEN_URL = "http://192.168.0.29:3000";
const DEV_CHAT_SCREEN_URL = "http://192.168.0.29:3002/chatlist";
const DEV_PROFILE_SCREEN_URL = "http://192.168.0.29:3001";
const DEV_SERVER_URL = "http://192.168.0.29:8000";

const HOME_SCREEN_URL = "https://preeminent-licorice-96005b.netlify.app";
const CHAT_SCREEN_URL = "https://cosmic-semolina-b6e8c3.netlify.app/chatlist";
const PROFILE_SCREEN_URL = "https://shiny-druid-4172be.netlify.app";
const SERVER_URL =
  "http://sinderproject-env.eba-p3ciumxi.us-east-1.elasticbeanstalk.com";

const ENV = {
  dev: {
    HOME_SCREEN_URL: DEV_HOME_SCREEN_URL,
    CHAT_SCREEN_URL: DEV_CHAT_SCREEN_URL,
    PROFILE_SCREEN_URL: DEV_PROFILE_SCREEN_URL,
    SERVER_URL: DEV_SERVER_URL,
  },
  prod: {
    HOME_SCREEN_URL: HOME_SCREEN_URL,
    CHAT_SCREEN_URL: CHAT_SCREEN_URL,
    PROFILE_SCREEN_URL: PROFILE_SCREEN_URL,
    SERVER_URL: SERVER_URL,
  },
};

const getEnvVars = (env = Constants.manifest.releaseChannel) => {
  if (__DEV__) {
    return ENV.dev;
  } else if (env === "prod") {
    return ENV.prod;
  }
};

export default getEnvVars;

```

위 코드가 dev 모드일 때와 production 모드일 때를 구분해서 환경변수를 반환해주기 때문에 걱정없이 쓰셔도 됩니다.
이제부터 환경변수를 사용하실 때는 아래와 같이 불러와서 사용하시면 됩니다.
```
import getEnvVars from "../../secrets";

...

const { HOME_SCREEN_URL } = getEnvVars();
```

추가)
react-native-webiew 깃허브 이슈에 [소켓이 동작하지 않는다는 글](https://github.com/react-native-webview/react-native-webview/issues/2540)을 올렸습니다. 
이미 관련 이슈가 한 개 존재하지만 별 다른 솔루션 없이 closed 되었기 때문에 제가 다시 올렸습니다.

## 변경 또는 추가한 로직

설치한 라이브러리:
- eslint-plugin-react-hooks - RN 리포지토리에는 리액트 훅 린트가 빠져있는 것을 보고 설치했습니다.
- socket.io-client - 네이티브 채팅방을 구현하기 위해 설치했습니다.
- @react-navigation/native-stack - 스택 네비게이터 스크린을 만들기 위해
- axios - 프로필 탭에서 채팅창에 입장할 때는 상대방의 id 만 알고, 이름과 이미지는 모르기 때문에 서버에 요청하는 로직을 만들기 위해 설치했습니다.
- dayjs - 각 채팅 메시지의 시간을 로컬 타임으로 변환해서 보여주기 위해 설치했습니다.